### PR TITLE
set refreshRate to 30

### DIFF
--- a/LiveSplit.GTAVC.asl
+++ b/LiveSplit.GTAVC.asl
@@ -52,6 +52,9 @@ state("gta-vc", "Japanese")
 
 startup
 {
+	// Set the autosplitter refresh rate (lower = less CPU and less accurate, higher = more CPU usage and more accurate) default: 60
+	refreshRate = 30;
+	
 	// List of mission memory addresses (for 1.0, see below for where offsets get added)
 	
 	// Collectible addresses

--- a/Releases/Vice City/LiveSplit.GTAVC.asl
+++ b/Releases/Vice City/LiveSplit.GTAVC.asl
@@ -52,6 +52,9 @@ state("gta-vc", "Japanese")
 
 startup
 {
+	// Set the autosplitter refresh rate (lower = less CPU and less accurate, higher = more CPU usage and more accurate) default: 60
+	refreshRate = 30;
+	
 	// List of mission memory addresses (for 1.0, see below for where offsets get added)
 	
 	// Collectible addresses


### PR DESCRIPTION
use the built-in refreshRate variable to set the autosplitter update rate to 30 times per second (60 by default, unnecessary cpu usage)