### PR TITLE
fix OMFSplit doing literally nothing

### DIFF
--- a/LiveSplit.GTAVC.asl
+++ b/LiveSplit.GTAVC.asl
@@ -524,7 +524,9 @@ split
 			if (settings["OMFSplit"]) {
 				vars.queuedSplit = true;
 			}
+			else {
 				vars.doSplit = true;
+			}
 		}
 	}
 	
@@ -594,8 +596,9 @@ split
 		vars.doSplit = true;
 	}
 	
-	if (vars.doSplit)
+	if (vars.doSplit) {
 		return true;
+	}
 }
 
 start

--- a/Releases/Vice City/LiveSplit.GTAVC.asl
+++ b/Releases/Vice City/LiveSplit.GTAVC.asl
@@ -524,7 +524,9 @@ split
 			if (settings["OMFSplit"]) {
 				vars.queuedSplit = true;
 			}
+			else {
 				vars.doSplit = true;
+			}
 		}
 	}
 	
@@ -589,13 +591,14 @@ split
 	}
 
 	// Splits for the final split of Any%.
-	if (settings["btgFinalSplit"] && vars.memoryWatchers["kyfc1"].Current == 245 && vars.memoryWatchers["kyfc2"].Current > vars.memoryWatchers["kyfc3"].Current && !vars.split.Contains("btgFinalSplit")) {
+	if (settings["btgFinalSplit"] && vars.memoryWatchers["kyfc1"].Current == 245 && vars.memoryWatchers["kyfc2"].Current > vars.memoryWatchers["kyfc3"].Current && !vars.Split.Contains("btgFinalSplit")) {
 		vars.split.Add("btgFinalSplit");
 		vars.doSplit = true;
 	}
 	
-	if (vars.doSplit)
+	if (vars.doSplit) {
 		return true;
+	}
 }
 
 start

--- a/Releases/Vice City/LiveSplit.GTAVC.asl
+++ b/Releases/Vice City/LiveSplit.GTAVC.asl
@@ -591,7 +591,7 @@ split
 	}
 
 	// Splits for the final split of Any%.
-	if (settings["btgFinalSplit"] && vars.memoryWatchers["kyfc1"].Current == 245 && vars.memoryWatchers["kyfc2"].Current > vars.memoryWatchers["kyfc3"].Current && !vars.Split.Contains("btgFinalSplit")) {
+	if (settings["btgFinalSplit"] && vars.memoryWatchers["kyfc1"].Current == 245 && vars.memoryWatchers["kyfc2"].Current > vars.memoryWatchers["kyfc3"].Current && !vars.split.Contains("btgFinalSplit")) {
 		vars.split.Add("btgFinalSplit");
 		vars.doSplit = true;
 	}


### PR DESCRIPTION
Very minor changes, but makes OMFsplit kinda functional, I've done small testing but the ASL is always broken so im not too stressed out.

Main issue:
It never actually prevented splitting on mission end if OMFsplit was enabled (the else statement was missing).

this works (abit) but it's not revolutionary:
To split on a specific mission start you need to check OMFSplit and the last mission before the mission you want to split on.

When the checked mission passes:
1) Flag is set.
2) If OMF variable increases it checks if any of these are active:
Vigilante, Paramedic, Firefighter, Taxi, Rampage, Phonecall, Save Game
... and will not split if any of those are met. If none are met then it splits.
3) Clears the flag.

small test i ran https://youtu.be/jhs6oCNStwg
I had these options checked:
Messing With the Man
OMFSplit