### PR TITLE
VC: Add support for SteamStub-less Steam EXE

### DIFF
--- a/LiveSplit.GTAVC.asl
+++ b/LiveSplit.GTAVC.asl
@@ -402,6 +402,12 @@ init
 		version = "Steam";
 		vars.offset = -0xFF8;
 	}
+
+	else if (modules.First().ModuleMemorySize == 6553600)
+	{
+		version = "Steam";
+		vars.offset = -0xFF8;
+	}
 	
 	// Detects current game version if RU Steam (also maybe detects 1.1?).
 	// Russian Steam version uses the same stuff as 1.1.

--- a/Releases/Vice City/LiveSplit.GTAVC.asl
+++ b/Releases/Vice City/LiveSplit.GTAVC.asl
@@ -402,6 +402,12 @@ init
 		version = "Steam";
 		vars.offset = -0xFF8;
 	}
+
+	else if (modules.First().ModuleMemorySize == 6553600)
+	{
+		version = "Steam";
+		vars.offset = -0xFF8;
+	}
 	
 	// Detects current game version if RU Steam (also maybe detects 1.1?).
 	// Russian Steam version uses the same stuff as 1.1.


### PR DESCRIPTION
The VC Steam version shared on the Dicsord is the Steam version with the SteamStub DRM removed, which caused the autosplitter version detection to fail due to the EXE size change. This PR just adds a check for that version.

I've tested the main stuff and the memory addresses didn't seem to change, so should be good to merge as-is.